### PR TITLE
Fix Xcode autocompletion with compilation units

### DIFF
--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -873,7 +873,7 @@
 			_p(3,'files = (')
 			tree.traverse(tr, {
 				onleaf = function(node)
-					if xcode.getbuildcategory(node) == "Sources" then
+					if xcode.getbuildcategory(node) == "Sources" and node.buildid then
 						_p(4,'%s /* %s in Sources */,', node.buildid, node.name)
 					end
 				end

--- a/modules/xcode/xcode_project.lua
+++ b/modules/xcode/xcode_project.lua
@@ -16,6 +16,39 @@
 	local tree = p.tree
 
 --
+-- Checks if a node must be excluded completely from a target or not. It will
+-- return true only if the node has the "ExcludeFromBuild" flag in all the
+-- configurations.
+--
+-- @param node
+--    The node to check.
+-- @param prj
+--    The project being generated.
+-- @returns
+--    A boolean, telling whether the node must be excluded from its target or not.
+--
+	function xcode.mustExcludeFromTarget(node, prj)
+		if not node.configs then
+			return false
+		end
+
+		local value
+		for cfg in premake.project.eachconfig(prj) do
+			local filecfg = premake.fileconfig.getconfig(node, cfg)
+			if filecfg then
+				local newValue = not not filecfg.flags.ExcludeFromBuild
+				if value == nil then
+					value = newValue
+				elseif value ~= newValue then
+					print("WARNING: " .. node.name .. " is excluded in just some configurations. Autocompletion will not work correctly on this file in Xcode.")
+					return false
+				end
+			end
+		end
+		return value
+	end
+
+--
 -- Create a tree corresponding to what is shown in the Xcode project browser
 -- pane, with nodes for files and folders, resources, frameworks, and products.
 --
@@ -109,7 +142,7 @@
 				node.isResource = xcode.isItemResource(prj, node)
 
 				-- assign build IDs to buildable files
-				if xcode.getbuildcategory(node) and not node.excludefrombuild then
+				if xcode.getbuildcategory(node) and not node.excludefrombuild and not xcode.mustExcludeFromTarget(node, tr.project) then
 					node.buildid = xcode.newid(node.name, "build", node.path)
 				end
 


### PR DESCRIPTION
Xcode's autocompletion gets disabled when a file is added to the exclude list. Unfortunately, the compilation units module adds the ExcludeFromBuild flag to all the source files, and the Premake Xcode module translates it into adding them to the Xcode exclude list.

This commit checks if a file must be excluded in all the configurations and in that case it removes the file from the target, so there's no need to add it to any exclusion list. In case a file is excluded in just some configurations, it prints a warning and keeps the old behavior for that file.