### PR TITLE
Fix xcodebuildresources with paths that contain special characters

### DIFF
--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -61,7 +61,7 @@
 				if list then
 					if type(list) == "table" then
 						for _,v in pairs(list) do
-							if string.find(item, v) then
+							if string.find(item, v, 1, true) then
 								return true
 							end
 						end


### PR DESCRIPTION
The resource paths were used as patterns, which interpreted some special characters. This PR changes it to use a plain search.

It was uncovered when trying to add the Firebase config file, which is called GoogleService-Info.plist (the minus sign is a special character in Lua's patterns).

I've opened a PR to push this change upstream too: https://github.com/premake/premake-core/pull/1271