### PR TITLE
Add swift files support

### DIFF
--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -39,6 +39,7 @@
 			[".icns"] = "Resources",
 			[".s"] = "Sources",
 			[".S"] = "Sources",
+			[".swift"] = "Sources",
 		}
 		if node.isResource then
 			return "Resources"
@@ -143,7 +144,7 @@
 			[".bmp"]       = "image.bmp",
 			[".wav"]       = "audio.wav",
 			[".xcassets"]  = "folder.assetcatalog",
-
+			[".swift"]     = "sourcecode.swift",
 		}
 		return types[path.getextension(node.path)] or "text"
 	end

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -237,10 +237,10 @@
 					value[k] = nil
 				end
 			end
-			--if #value == 1 then
-				--_p(level, '%s = %s;', stringifySetting(name), stringifySetting(value[1]))
-			--end
-			if #value >= 1 then
+			if #value == 1 then
+				_p(level, '%s = %s;', stringifySetting(name), stringifySetting(value[1]))
+			end
+			if #value > 1 then
 				_p(level, '%s = (', stringifySetting(name))
 				for _, item in ipairs(value) do
 					_p(level + 1, '%s,', stringifySetting(item))


### PR DESCRIPTION
Add support for swift files
Also, generate single value settings as ``name=value;``instead of ``name = (value, );`` because cocoapods is not able to load single values as non string when found in the second format. This makes it fail to parse ``SWIFT_VERSION`` version setting from the project when doing the ``pod install``part