### PR TITLE
Support xcodebuildsettings at project or target level

### DIFF
--- a/modules/xcode/_preload.lua
+++ b/modules/xcode/_preload.lua
@@ -24,6 +24,18 @@
 	}
 
 	p.api.register {
+		name = "xcodeprojectbuildsettings",
+		scope = "config",
+		kind = "key-array",
+	}
+
+	p.api.register {
+		name = "xcodetargetbuildsettings",
+		scope = "config",
+		kind = "key-array",
+	}
+
+	p.api.register {
 		name = "xcodebuildresources",
 		scope = "config",
 		kind = "list",

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -2062,6 +2062,64 @@
 		]]
 	end
 
+	function suite.XCBuildConfigurationTarget_XcodeTargetBuildSettings()
+		_TARGET_OS = "ios"
+		iosfamily "Universal"
+		xcodetargetbuildsettings {
+			["TEST_VALUE"] = 1
+		}
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_VALUE = 1;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationTarget_OverrideByXcodeTargetBuildSettings()
+		_TARGET_OS = "ios"
+		iosfamily "Universal"
+		xcodebuildsettings {
+			["TEST_VALUE"] = 0
+		}
+		xcodetargetbuildsettings {
+			["TEST_VALUE"] = 1
+		}
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_VALUE = 1;
+			};
+			name = Debug;
+		};
+		]]
+	end
 
 ---------------------------------------------------------------------------
 -- XCBuildConfiguration_Project tests
@@ -3489,6 +3547,33 @@
 		]]
 	end
 
+	function suite.XCBuildConfigurationProject_XcodeProjectBuildSettings()
+		workspace("MyWorkspace")
+		xcodeprojectbuildsettings {
+			["TEST_VALUE"] = 1
+		}
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+				TEST_VALUE = 1;
+			};
+			name = Debug;
+		};
+		]]
+	end
 
 ---------------------------------------------------------------------------
 -- XCBuildConfigurationList tests

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1300,6 +1300,7 @@
 		--settings['COMBINE_HIDPI_IMAGES'] = 'YES'
 
 		overrideSettings(settings, cfg.xcodebuildsettings)
+		overrideSettings(settings, cfg.xcodetargetbuildsettings)
 
 		_p(2,'%s /* %s */ = {', cfg.xcode.targetid, cfg.buildcfg)
 		_p(3,'isa = XCBuildConfiguration;')
@@ -1543,6 +1544,7 @@
 		xcode.XCBuildConfiguration_SwiftLanguageVersion(settings, cfg)
 
 		overrideSettings(settings, cfg.xcodebuildsettings)
+		overrideSettings(settings, cfg.xcodeprojectbuildsettings)
 
 		_p(2,'%s /* %s */ = {', cfg.xcode.projectid, cfg.buildcfg)
 		_p(3,'isa = XCBuildConfiguration;')


### PR DESCRIPTION
`xcodebuildsettings` are used both by project ([here](https://github.com/socialpoint/premake-core/blob/stable/modules/xcode/xcode_common.lua#L1545)) and target ([here](https://github.com/socialpoint/premake-core/blob/stable/modules/xcode/xcode_common.lua#L1302)). All the settings end up in both levels. This can be a problem with some targets that inherit settings from the project level that are not intended to be at that level. To fix this I created `xcodeprojectbuildsettings` and `xcodetargetbuildsettings`.

**xcodebuildsettings**
Define settings at **BOTH** project and target level.

**xcodeprojectbuildsettings**
Define settings **ONLY** at project level. If a setting is defined both in `xcodebuildsettings` and `xcodeprojectbuildsettings` then `xcodeprojectbuildsettings` overrides it.

**xcodetargetbuildsettings**
Define settings **ONLY** at target level. If a setting is defined in `xcodebuildsettings` or `xcodeprojectbuildsettings` and `xcodetargetbuildsettings` then `xcodetargetbuildsettings` overrides it.