### PR TITLE
Require unistd.h for macosx in libzip

### DIFF
--- a/contrib/libzip/premake5.lua
+++ b/contrib/libzip/premake5.lua
@@ -19,3 +19,4 @@ project "zip-lib"
 
 	filter "system:macosx"
 		defines { "HAVE_SSIZE_T_LIBZIP" }
+		forceincludes { "unistd.h" }


### PR DESCRIPTION
**What does this PR do?**

Fixes the local build of premake5 on latest XCode.

**How does this PR change Premake's behavior?**

**Cherry-picks the commit [01c7a14](https://github.com/premake/premake-core/pull/2117/commits/01c7a142caa03ca9170fa7ee045719f4148b5156) from upstream** to force the inclusion of `<unistd.h>` in libzip (3rd-party dependency of premake5) on OSX. Otherwise we can't build it, because it implicitly relies on functions declared in said header, e.g. `getpid`.

Ref: https://github.com/premake/premake-core/pull/2117
Ref: https://github.com/premake/premake-core/issues/2092

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*

JIRA: https://socialpoint.atlassian.net/browse/DCT-614
