### PR TITLE
GitHub action Build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
     macos:
-        if: (${{ inputs.platform }} == 'macos' || ${{ inputs.platform }} == 'all')
+        if: ${{ inputs.platform == 'macos' || inputs.platform == 'all' }}
         runs-on: macos-latest
         timeout-minutes: 30
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # https://github.com/ilammy/msvc-dev-cmd/releases/tag/v1.13.0
         - name: Build
           shell: cmd
-          run: nmake -f Bootstrap.mak MSDEV=vs2017 windows-msbuild PLATFORM=x64 CONFIG=Release
+          run: nmake -f Bootstrap.mak MSDEV=vs2022 windows-msbuild PLATFORM=x64 CONFIG=Release
         - name: Upload Artifacts
           uses: actions/upload-artifact@v4
           with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,14 @@ jobs:
         runs-on: macos-latest
         timeout-minutes: 30
         steps:
-            - run: echo "Building for macos..."
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Build
+          run: make -f Bootstrap.mak osx
+        - name: Upload Artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: premake5-macos
+            path: |
+                bin/release/premake5
+                bin/release/libluasocket.dylib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,25 @@ jobs:
             path: |
                 bin/release/premake5
                 bin/release/libluasocket.dylib
-                
+
+    windows:
+        if: ${{ inputs.platform == 'windows' || inputs.platform == 'all' }}
+        runs-on: windows-latest
+        timeout-minutes: 30
+        steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Build
+          shell: cmd
+          run: nmake -f Bootstrap.mak MSDEV=vs2017 windows-msbuild PLATFORM=x64 CONFIG=Release
+        - name: Upload Artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: premake5-windows
+            path: |
+                bin/release/premake5.exe
+                bin/release/luasocket.dll
+
     linux:
         if: ${{ inputs.platform == 'linux' || inputs.platform == 'all' }}
         runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
         steps:
         - name: Checkout
           uses: actions/checkout@v4
+        - name: Setup Developer Command Prompt for Microsoft Visual C++
+          uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # https://github.com/ilammy/msvc-dev-cmd/releases/tag/v1.13.0
         - name: Build
           shell: cmd
           run: nmake -f Bootstrap.mak MSDEV=vs2017 windows-msbuild PLATFORM=x64 CONFIG=Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,14 @@ jobs:
           uses: actions/checkout@v4
         - name: Build
           run: make -f Bootstrap.mak osx
+        - name: Rename files
+          run: mv bin/release/premake5 bin/release/premake5-macos
         - name: Upload Artifacts
           uses: actions/upload-artifact@v4
           with:
             name: premake5-macos
             path: |
-                bin/release/premake5
+                bin/release/premake5-macos
                 bin/release/libluasocket.dylib
 
     windows:
@@ -61,10 +63,12 @@ jobs:
           uses: actions/checkout@v4
         - name: Build
           run: make -f Bootstrap.mak linux
+        - name: Rename files
+          run: mv bin/release/premake5 bin/release/premake5-linux
         - name: Upload Artifacts
           uses: actions/upload-artifact@v4
           with:
             name: premake5-linux
             path: |
-                bin/release/premake5
+                bin/release/premake5-linux
                 bin/release/libluasocket.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
     macos:
-        if: ${{ inputs.platform }} == 'macos' || ${{ inputs.platform }} == 'all'
+        if: (${{ inputs.platform }} == 'macos' || ${{ inputs.platform }} == 'all')
         runs-on: macos-latest
         timeout-minutes: 30
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,20 @@ jobs:
             path: |
                 bin/release/premake5
                 bin/release/libluasocket.dylib
+                
+    linux:
+        if: ${{ inputs.platform == 'linux' || inputs.platform == 'all' }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Build
+          run: make -f Bootstrap.mak linux
+        - name: Upload Artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: premake5-linux
+            path: |
+                bin/release/premake5
+                bin/release/libluasocket.so


### PR DESCRIPTION
Continue the work started here https://github.com/socialpoint/premake-core/pull/16.

Added support for:

- macos (see [example](https://github.com/socialpoint/premake-core/actions/runs/14663388864))
- linux (see [example](https://github.com/socialpoint/premake-core/actions/runs/14663564793))
- windows (see [example](https://github.com/socialpoint/premake-core/actions/runs/14664589034))
- all (see [example](https://github.com/socialpoint/premake-core/actions/runs/14664745534))
