### PR TITLE
Fix vstudio/MSC not supporting the C++23 flag yet

### DIFF
--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -1270,6 +1270,54 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<LanguageStandard>stdcpp20</LanguageStandard>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
+</ClCompile>
+		]]
+	end
+
+	function suite.onLanguage_Cpp23_VS2017()
+		p.action.set("vs2017")
+
+		cppdialect 'C++23'
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<LanguageStandard>stdcpplatest</LanguageStandard>
+</ClCompile>
+		]]
+	end
+
+	function suite.onLanguage_Cpp23_VS2019()
+		p.action.set("vs2019")
+
+		cppdialect 'C++23'
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<LanguageStandard>stdcpplatest</LanguageStandard>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
+</ClCompile>
+		]]
+	end
+
+	function suite.onLanguage_Cpp23_VS2022()
+		p.action.set("vs2022")
+
+		cppdialect 'C++23'
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<LanguageStandard>stdcpplatest</LanguageStandard>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 </ClCompile>
 		]]
 	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1413,7 +1413,7 @@
 			elseif (cfg.cppdialect == "C++20") then
 				m.element("LanguageStandard", nil, iif(_ACTION == "vs2017", 'stdcpplatest', 'stdcpp20'))
 			elseif (cfg.cppdialect == "C++23") then
-				m.element("LanguageStandard", nil, iif(_ACTION == "vs2017", 'stdcpplatest', 'stdcpp23'))
+				m.element("LanguageStandard", condition, 'stdcpplatest')
 			elseif (cfg.cppdialect == "C++latest") then
 				m.element("LanguageStandard", nil, 'stdcpplatest')
 			end

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -128,7 +128,7 @@
 			["C++14"] = "/std:c++14",
 			["C++17"] = "/std:c++17",
 			["C++20"] = "/std:c++20",
-			["C++23"] = "/std:c++23",
+			["C++23"] = "/std:c++latest",
 			["C++latest"] = "/std:c++latest"
 		},
 		exceptionhandling = {

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -307,7 +307,7 @@
 	function suite.cppdialectCpp23()
 		cppdialect "C++23"
 		prepare()
-		test.contains('/std:c++23', msc.getcxxflags(cfg))
+		test.contains('/std:c++latest', msc.getcxxflags(cfg))
 	end
 
 	function suite.cppdialectCppLatest()


### PR DESCRIPTION
They need to use C++Latest to get C++23 features instead.

On a dev's machine, we got:
![image](https://github.com/user-attachments/assets/a1cf118f-0b30-4942-b34f-34a6972a564b)
