### PR TITLE
Handle nil files in project configuration

### DIFF
--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -174,7 +174,7 @@
 
 
 		for prj in p.workspace.eachproject(wks) do
-			local files = table.shallowcopy(prj._.files)
+			local files = table.shallowcopy(prj._.files or {})
 			for cfg in p.project.eachconfig(prj) do
 				table.foreachi(files, function(node)
 					addFile(cfg, node)


### PR DESCRIPTION
**What does this PR do?**

Where project files are nil (undefined), this ensures the shallowcopy will not trigger an exception.
